### PR TITLE
syn.tcl: use pipeline-logic retiming instead of adaptive retiming

### DIFF
--- a/fpu-wrappers/resources/syn.tcl
+++ b/fpu-wrappers/resources/syn.tcl
@@ -41,7 +41,8 @@ set_output_delay 0.02 -clock clk [all_outputs]
 link
 uniquify
 ungroup -flatten -all
-compile_ultra -retime
+set_optimize_registers
+compile_ultra
 
 # export
 write -format ddc -hierarchy -output [format "%s%s" $toplevel_name ".ddc"]


### PR DESCRIPTION
Design compiler performs `adaptive retiming` when using `compile_ultra` command with the `-retime` option, but it does not replace the `pipeline-logic retiming` engine available with the `set_optimize_registers` command. For data-path retiming purpose, we should use `set_optimize_registers` command instead of `-retime`. See "Comparing Adaptive Retiming With Pipelined-Logic Retiming" in "Design Compiler User Guide" for more details.